### PR TITLE
Submit custom metrics via CloudWatch Logs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 CHANGELOG
 =========
+# v2 / 2019-06-10
+
+* Support submitting metrics through CloudWatch Logs
+* Support submitting metrics to `datadoghq.eu`
+* Support KMS-encrypted DD API Key
+* Fix a few bugs
 
 # v1 / 2019-05-06
 
 * First release
 * Support submitting distribution metrics from Lambda functions
-* Supports distributed tracing between serverful and serverless services
+* Support distributed tracing between serverful and serverless services

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt -t ./python/lib/$runtime/site-packages
 
 # Install datadog_lambda
-COPY datadog_lambda ./python/lib/$runtime/site-packages
+COPY datadog_lambda ./python/lib/$runtime/site-packages/datadog_lambda
 
 # Remove *.pyc files
 RUN find ./python/lib/$runtime/site-packages -name \*.pyc -delete

--- a/README.md
+++ b/README.md
@@ -12,10 +12,17 @@ arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Python37:<VERSION>
 
 Replace `<AWS_REGION>` with the region where your Lambda function lives, and `<VERSION>` with the desired (or the latest) version that can be found from [CHANGELOG](CHANGELOG.md).
 
-The following Datadog environment variables must be defined via [AWS CLI](https://docs.aws.amazon.com/lambda/latest/dg/env_variables.html) or [Serverless Framework](https://serverless-stack.com/chapters/serverless-environment-variables.html):
+The Datadog API must be defined as an environment variable via [AWS CLI](https://docs.aws.amazon.com/lambda/latest/dg/env_variables.html) or [Serverless Framework](https://serverless-stack.com/chapters/serverless-environment-variables.html):
 
-* DATADOG_API_KEY
-* DATADOG_APP_KEY
+* DD_API_KEY or DD_KMS_API_KEY (if encrypted by KMS)
+
+Set the following Datadog environment variable to `datadoghq.eu` to send your data to the Datadog EU site.
+
+* DD_SITE
+
+If your Lambda function powers a performance-critical task (e.g., a consumer-facing API). You can avoid the added latencies of metric-submitting API calls, by setting the following Datadog environment variable to `True`. Custom metrics will be submitted asynchronously through CloudWatch Logs and [the Datadog log forwarder](https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring).
+
+* DATADOG_FLUSH_TO_LOG
 
 ### The Serverless Framework
 
@@ -40,7 +47,6 @@ functions:
       - arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:1
     environment:
       DATADOG_API_KEY: xxx
-      DATADOG_APP_KEY: yyy
 ```
 
 

--- a/datadog_lambda/__init__.py
+++ b/datadog_lambda/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1"
+__version__ = "2"

--- a/datadog_lambda/constants.py
+++ b/datadog_lambda/constants.py
@@ -3,6 +3,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2019 Datadog, Inc.
 
+
 # Datadog trace sampling priority
 class SamplingPriority(object):
     USER_REJECT = -1

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -55,8 +55,7 @@ def get_dd_trace_context():
     Return the Datadog trace context to be propogated on the outgoing requests.
 
     If the Lambda function is invoked by a Datadog-traced service, a Datadog
-    trace
-    context may already exist, and it should be used. Otherwise, use the
+    trace context may already exist, and it should be used. Otherwise, use the
     current X-Ray trace entity.
 
     Most of widely-used HTTP clients are patched to inject the context

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 aws-xray-sdk==2.4.2
 datadog==0.28.0
 wrapt==1.11.1
+setuptools==40.8.0
+boto3==1.9.160

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,27 @@
+from setuptools import setup
+from os import path
+from io import open
+
+here = path.abspath(path.dirname(__file__))
+
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='ddlambda',
+    version='0.2.0',
+    description='The Datadog AWS Lambda Layer',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    url='https://github.com/DataDog/datadog-lambda-layer-python',
+    author='Datadog, Inc.',
+    author_email='dev@datadoghq.com',
+    classifiers=[
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
+    keywords='datadog aws lambda layer',
+    packages=['datadog_lambda'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4',
+)

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -3,6 +3,7 @@ FROM python:$python_version
 
 ENV PYTHONDONTWRITEBYTECODE True
 
+COPY .flake8 .flake8
 COPY requirements.txt requirements.txt
 COPY requirements-dev.txt requirements-dev.txt
 RUN pip install -r requirements.txt

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 try:
     from unittest.mock import patch, call, ANY
@@ -35,9 +36,28 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         lambda_event = {}
         lambda_context = {}
         lambda_handler(lambda_event, lambda_context)
+
         self.mock_metric_lambda_stats.distribution.assert_has_calls([
-            call('test.metric', 100, tags=ANY)
+            call('test.metric', 100, timestamp=None, tags=ANY)
         ])
         self.mock_wrapper_lambda_stats.flush.assert_called()
         self.mock_extract_dd_trace_context.assert_called_with(lambda_event)
         self.mock_patch_all.assert_called()
+
+    def test_datadog_lambda_wrapper_flush_to_log(self):
+        os.environ["DATADOG_FLUSH_TO_LOG"] = 'True'
+
+        @datadog_lambda_wrapper
+        def lambda_handler(event, context):
+            lambda_metric("test.metric", 100)
+
+        lambda_event = {}
+        lambda_context = {}
+        lambda_handler(lambda_event, lambda_context)
+
+        self.mock_metric_lambda_stats.distribution.assert_not_called()
+        self.mock_wrapper_lambda_stats.flush.assert_not_called()
+        self.mock_extract_dd_trace_context.assert_called_with(lambda_event)
+        self.mock_patch_all.assert_called()
+
+        del os.environ["DATADOG_FLUSH_TO_LOG"]


### PR DESCRIPTION
### What does this PR do?

Allow custom metrics to be submitted to CloudWatch Logs, and then be forwarded by Datadog log forwarder. This option can be enabled by setting environment variable `DATADOG_FLUSH_TO_LOG` to `True`.

### Motivation

Writting metrics to logs rather than sending to Datadog metric intake endpoint helps avoid adding latencies to the Lambda executions.

### Testing Guidelines

Upgrade to the latest version of datadog lambda layer and log forwarder.
