### PR TITLE
Shorten the metric log keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+# v3 / 2019-06-18
+
+* Log metrics in a compact format
+
 # v2 / 2019-06-10
 
 * Support submitting metrics through CloudWatch Logs

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Set the following Datadog environment variable to `datadoghq.eu` to send your da
 
 If your Lambda function powers a performance-critical task (e.g., a consumer-facing API). You can avoid the added latencies of metric-submitting API calls, by setting the following Datadog environment variable to `True`. Custom metrics will be submitted asynchronously through CloudWatch Logs and [the Datadog log forwarder](https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring).
 
-* DATADOG_FLUSH_TO_LOG
+* DD_FLUSH_TO_LOG
 
 ### The Serverless Framework
 

--- a/datadog_lambda/__init__.py
+++ b/datadog_lambda/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "2"
+__version__ = "3"

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -42,7 +42,7 @@ def lambda_metric(metric_name, value, timestamp=None, tags=None):
     Submit a data point to Datadog distribution metrics.
     https://docs.datadoghq.com/graphing/metrics/distributions/
 
-    When DATADOG_LOG_FORWARDER is True, write metric to log, and
+    When DD_FLUSH_TO_LOG is True, write metric to log, and
     wait for the Datadog Log Forwarder Lambda function to submit
     the metrics asynchronously.
 
@@ -51,7 +51,7 @@ def lambda_metric(metric_name, value, timestamp=None, tags=None):
     background thread.
     """
     tags = _tag_dd_lambda_layer(tags)
-    if os.environ.get('DATADOG_FLUSH_TO_LOG') == 'True':
+    if os.environ.get('DD_FLUSH_TO_LOG', '').lower() == 'true':
         print(json.dumps({
             'm': metric_name,
             'v': value,

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -53,10 +53,10 @@ def lambda_metric(metric_name, value, timestamp=None, tags=None):
     tags = _tag_dd_lambda_layer(tags)
     if os.environ.get('DATADOG_FLUSH_TO_LOG') == 'True':
         print(json.dumps({
-            'metric_name': metric_name,
-            'value': value,
-            'timestamp': timestamp or int(time.time()),
-            'tags': tags
+            'm': metric_name,
+            'v': value,
+            'e': timestamp or int(time.time()),
+            't': tags
         }))
     else:
         lambda_stats.distribution(

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -33,7 +33,7 @@ class _LambdaDecorator(object):
 
     def __init__(self, func):
         self.func = func
-        self.flush_to_log = os.environ.get('DATADOG_FLUSH_TO_LOG') == 'True'
+        self.flush_to_log = os.environ.get('DD_FLUSH_TO_LOG', '').lower() == 'true'
 
     def _before(self, event, context):
         try:

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -30,9 +30,9 @@ class TestLambdaMetric(unittest.TestCase):
         ])
 
     def test_lambda_metric_flush_to_log(self):
-        os.environ["DATADOG_FLUSH_TO_LOG"] = 'True'
+        os.environ["DD_FLUSH_TO_LOG"] = 'True'
 
         lambda_metric('test', 1)
         self.mock_metric_lambda_stats.distribution.assert_not_called()
 
-        del os.environ["DATADOG_FLUSH_TO_LOG"]
+        del os.environ["DD_FLUSH_TO_LOG"]

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -45,7 +45,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         self.mock_patch_all.assert_called()
 
     def test_datadog_lambda_wrapper_flush_to_log(self):
-        os.environ["DATADOG_FLUSH_TO_LOG"] = 'True'
+        os.environ["DD_FLUSH_TO_LOG"] = 'True'
 
         @datadog_lambda_wrapper
         def lambda_handler(event, context):
@@ -60,4 +60,4 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         self.mock_extract_dd_trace_context.assert_called_with(lambda_event)
         self.mock_patch_all.assert_called()
 
-        del os.environ["DATADOG_FLUSH_TO_LOG"]
+        del os.environ["DD_FLUSH_TO_LOG"]


### PR DESCRIPTION
### What does this PR do?

Use a slightly more compact format to log the submitted metrics.

### Motivation

Reduce CW log cost.
