### PR TITLE
Guarantee trace headers will always be treated with case insensitivity

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -27,9 +27,11 @@ def extract_dd_trace_context(event):
     """
     global dd_trace_context
     headers = event.get('headers', {})
-    trace_id = headers.get(TraceHeader.TRACE_ID)
-    parent_id = headers.get(TraceHeader.PARENT_ID)
-    sampling_priority = headers.get(TraceHeader.SAMPLING_PRIORITY)
+    lowercase_headers = {k.lower(): v for k, v in headers.items()}
+
+    trace_id = lowercase_headers.get(TraceHeader.TRACE_ID)
+    parent_id = lowercase_headers.get(TraceHeader.PARENT_ID)
+    sampling_priority = lowercase_headers.get(TraceHeader.SAMPLING_PRIORITY)
     if trace_id and parent_id and sampling_priority:
         dd_trace_context = {
             'trace-id': trace_id,

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -88,6 +88,23 @@ class TestExtractAndGetDDTraceContext(unittest.TestCase):
             XraySubsegment.NAMESPACE
         )
 
+    def test_with_complete_datadog_trace_headers_with_mixed_casing(self):
+        extract_dd_trace_context({
+            'headers': {
+                'X-Datadog-Trace-Id': '123',
+                'X-Datadog-Parent-Id': '321',
+                'X-Datadog-Sampling-Priority': '1',
+            }
+        })
+        self.assertDictEqual(
+            get_dd_trace_context(),
+            {
+                TraceHeader.TRACE_ID: '123',
+                TraceHeader.PARENT_ID: '65535',
+                TraceHeader.SAMPLING_PRIORITY: '1',
+            }
+        )
+
 
 class TestXRayContextConversion(unittest.TestCase):
 


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-python/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Reads incoming trace headers as case insensitive.

### Motivation

Some libraries/frameworks send headers with mixed casing, this should guarantee support for those.

### Testing Guidelines

How did you test this pull request?

### Additional Notes

Anything else we should know when reviewing?
