### PR TITLE
Support trace and log correlation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ If your Lambda function powers a performance-critical task (e.g., a consumer-fac
 
 - DD_FLUSH_TO_LOG
 
+To connect logs and traces, set the environment variable below to `True`. The default format of the AWS provided `LambdaLoggerHandler` will be overridden to inject `dd.trace_id` and `dd.span_id`. The default Datadog lambda log integration pipeline will automatically parse them and map the `dd.trace_id` into the reserved [trace_id attribute](https://docs.datadoghq.com/logs/processing/#trace-id-attribute).
+
+- DD_LOGS_INJECTION
+
+To debug the Datadog Lambda Layer, set the environment variable below to `DEBUG`.
+
+- DD_LOG_LEVEL
+
 ### The Serverless Framework
 
 If your Lambda function is deployed using the Serverless Framework, refer to this sample `serverless.yml`.
@@ -210,6 +218,28 @@ The file content for `datadog-sampling-priority-2.json`:
 If your Lambda function is triggered by API Gateway via [the non-proxy integration](https://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-lambda-non-proxy-integration.html), then you have to [set up a mapping template](https://aws.amazon.com/premiumsupport/knowledge-center/custom-headers-api-gateway-lambda/), which passes the Datadog trace context from the incoming HTTP request headers to the Lambda function via the `event` object.
 
 If your Lambda function is deployed by the Serverless Framework, such a mapping template gets created by default.
+
+## Log and Trace Correlations
+
+To connect logs and traces, set the environment variable `DD_LOGS_INJECTION` to `True`. The log format of the AWS provided `LambdaLoggerHandler` will be overridden to inject `dd.trace_id` and `dd.span_id`. The default Datadog lambda log integration pipeline will automatically parse them and map the `dd.trace_id` into the reserved attribute [trace_id](https://docs.datadoghq.com/logs/processing/#trace-id-attribute).
+
+If you use a custom logger handler to log in json, you can manually inject the ids using the helper function `get_correlation_ids`.
+
+```python
+from datadog_lambda.wrapper import datadog_lambda_wrapper
+from ddtrace.helpers import get_correlation_ids
+
+@datadog_lambda_wrapper
+def lambda_handler(event, context):
+  trace_id, span_id = get_correlation_ids()
+  logger.info({
+    "message": "hello world",
+    "dd": {
+      "trace_id": trace_id,
+      "span_id": span_id
+    }
+  })
+```
 
 ## Opening Issues
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     install_requires=[
         'aws-xray-sdk==2.4.2',
         'datadog==0.28.0',
+        'ddtrace==0.28.0',
         'wrapt==1.11.1',
         'setuptools==40.8.0',
         'boto3==1.9.160'

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -24,6 +24,14 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         self.mock_extract_dd_trace_context = patcher.start()
         self.addCleanup(patcher.stop)
 
+        patcher = patch('datadog_lambda.wrapper.set_correlation_ids')
+        self.mock_set_correlation_ids = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch('datadog_lambda.wrapper.inject_correlation_ids')
+        self.mock_inject_correlation_ids = patcher.start()
+        self.addCleanup(patcher.stop)
+
         patcher = patch('datadog_lambda.wrapper.patch_all')
         self.mock_patch_all = patcher.start()
         self.addCleanup(patcher.stop)
@@ -42,6 +50,8 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         ])
         self.mock_wrapper_lambda_stats.flush.assert_called()
         self.mock_extract_dd_trace_context.assert_called_with(lambda_event)
+        self.mock_set_correlation_ids.assert_called()
+        self.mock_inject_correlation_ids.assert_not_called()
         self.mock_patch_all.assert_called()
 
     def test_datadog_lambda_wrapper_flush_to_log(self):
@@ -57,7 +67,21 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
 
         self.mock_metric_lambda_stats.distribution.assert_not_called()
         self.mock_wrapper_lambda_stats.flush.assert_not_called()
-        self.mock_extract_dd_trace_context.assert_called_with(lambda_event)
-        self.mock_patch_all.assert_called()
 
         del os.environ["DD_FLUSH_TO_LOG"]
+
+    def test_datadog_lambda_wrapper_inject_correlation_ids(self):
+        os.environ["DD_LOGS_INJECTION"] = 'True'
+
+        @datadog_lambda_wrapper
+        def lambda_handler(event, context):
+            lambda_metric("test.metric", 100)
+
+        lambda_event = {}
+        lambda_context = {}
+        lambda_handler(lambda_event, lambda_context)
+
+        self.mock_set_correlation_ids.assert_called()
+        self.mock_inject_correlation_ids.assert_called()
+
+        del os.environ["DD_LOGS_INJECTION"]


### PR DESCRIPTION
### What does this PR do?

Inject `dd.trace_id` and `dd.span_id` into logs for trace correlation.

### Motivation

Enable navigation from logs to the corresponding trace, vice versa.

