### PR TITLE
Submit metrics for invocations and errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# Version: 7 / 2019-10-24
+
+- Increment `aws.lambda.enhanced.invocations` and `aws.lambda.enhanced.errors` metrics for each invocation if `DD_ENHANCED_METRICS` env var is set to true.
+
 # Version: 6 / 2019-09-16
 
 - Support `DD_LOGS_INJECTION` for trace and log correlation

--- a/datadog_lambda/__init__.py
+++ b/datadog_lambda/__init__.py
@@ -1,6 +1,6 @@
 # The minor version corresponds to the Lambda layer version.
 # E.g.,, version 0.5.0 gets packaged into layer version 5.
-__version__ = '0.6.0'
+__version__ = '0.7.0'
 
 
 import os

--- a/datadog_lambda/cold_start.py
+++ b/datadog_lambda/cold_start.py
@@ -1,0 +1,25 @@
+_cold_start = True
+_lambda_container_initialized = False
+
+
+def set_cold_start():
+    """Set the value of the cold start global
+
+    This should be executed once per Lambda execution before the execution
+    """
+    global _cold_start
+    global _lambda_container_initialized
+    _cold_start = not _lambda_container_initialized
+    _lambda_container_initialized = True
+
+
+def is_cold_start():
+    """Returns the value of the global cold_start
+    """
+    return _cold_start
+
+
+def get_cold_start_tag():
+    """Returns the cold start tag to be used in metrics
+    """
+    return "cold_start:{}".format(str(is_cold_start()).lower())

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -76,9 +76,18 @@ def lambda_metric(metric_name, value, timestamp=None, tags=None):
         lambda_stats.distribution(metric_name, value, timestamp=timestamp, tags=tags)
 
 
+def are_enhanced_metrics_enabled():
+    """Check env var to find if enhanced metrics should be submitted
+    """
+    return os.environ.get("DD_ENHANCED_METRICS", "false").lower() == "true"
+
+
 def submit_invocations_metric(lambda_arn):
     """Increment aws.lambda.enhanced.invocations by 1
     """
+    if not are_enhanced_metrics_enabled():
+        return
+
     lambda_metric(
         "{}.invocations".format(ENHANCED_METRICS_NAMESPACE_PREFIX),
         1,
@@ -89,6 +98,9 @@ def submit_invocations_metric(lambda_arn):
 def submit_errors_metric(lambda_arn):
     """Increment aws.lambda.enhanced.errors by 1
     """
+    if not are_enhanced_metrics_enabled():
+        return
+
     lambda_metric(
         "{}.errors".format(ENHANCED_METRICS_NAMESPACE_PREFIX),
         1,

--- a/datadog_lambda/tags.py
+++ b/datadog_lambda/tags.py
@@ -1,0 +1,40 @@
+def parse_lambda_tags_from_arn(arn):
+    """Generate the list of lambda tags based on the data in the arn
+    Args:
+        arn (str): Lambda ARN.
+            ex: arn:aws:lambda:us-east-1:123597598159:function:my-lambda[:optional-version]
+    """
+    # Cap the number of times to split
+    split_arn = arn.split(":")
+
+    # If ARN includes version / alias at the end, drop it
+    if len(split_arn) > 7:
+        split_arn = split_arn[:7]
+
+    _, _, _, region, account_id, _, function_name = split_arn
+
+    return [
+        "region:{}".format(region),
+        "account_id:{}".format(account_id),
+        "functionname:{}".format(function_name),
+    ]
+
+
+def get_tags_from_context(context, cold_start_request_id):
+    """Uses properties of the Lambda context to create the list of tags
+
+    Args:
+        context (dict<str, multiple types>): context this Lambda was invoked with
+        cold_start_request_id (str): the first request ID to execute in this container
+
+    Returns:
+        tag list (str[]): list of string tags in key:value format
+    """
+    tags = parse_lambda_tags_from_arn(context.invoked_function_arn)
+    tags.append("memorysize:{}".format(context.memory_limit_in_mb))
+
+    did_request_cold_start = cold_start_request_id == context.aws_request_id
+    cold_start_tag = "cold_start:{}".format(str(did_request_cold_start).lower())
+    tags.append(cold_start_tag)
+
+    return tags

--- a/datadog_lambda/tags.py
+++ b/datadog_lambda/tags.py
@@ -18,23 +18,3 @@ def parse_lambda_tags_from_arn(arn):
         "account_id:{}".format(account_id),
         "functionname:{}".format(function_name),
     ]
-
-
-def get_tags_from_context(context, cold_start_request_id):
-    """Uses properties of the Lambda context to create the list of tags
-
-    Args:
-        context (dict<str, multiple types>): context this Lambda was invoked with
-        cold_start_request_id (str): the first request ID to execute in this container
-
-    Returns:
-        tag list (str[]): list of string tags in key:value format
-    """
-    tags = parse_lambda_tags_from_arn(context.invoked_function_arn)
-    tags.append("memorysize:{}".format(context.memory_limit_in_mb))
-
-    did_request_cold_start = cold_start_request_id == context.aws_request_id
-    cold_start_tag = "cold_start:{}".format(str(did_request_cold_start).lower())
-    tags.append(cold_start_tag)
-
-    return tags

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,7 +1,6 @@
 import unittest
 
-from datadog_lambda.tags import parse_lambda_tags_from_arn, get_tags_from_context
-from tests.test_wrapper import get_mock_context
+from datadog_lambda.tags import parse_lambda_tags_from_arn
 
 
 class TestMetricTags(unittest.TestCase):
@@ -25,36 +24,6 @@ class TestMetricTags(unittest.TestCase):
                 "region:us-west-1",
                 "account_id:1234597598159",
                 "functionname:other-function",
-            ],
-        )
-
-    def test_get_tags_from_context(self):
-        cold_start_request_id = "first-request-id"
-        self.assertListEqual(
-            get_tags_from_context(
-                get_mock_context(aws_request_id=cold_start_request_id),
-                cold_start_request_id,
-            ),
-            [
-                "region:us-west-1",
-                "account_id:123457598159",
-                "functionname:python-layer-test",
-                "memorysize:256",
-                "cold_start:true",
-            ],
-        )
-
-        self.assertListEqual(
-            get_tags_from_context(
-                get_mock_context(aws_request_id="non-cold-start-request-id"),
-                cold_start_request_id,
-            ),
-            [
-                "region:us-west-1",
-                "account_id:123457598159",
-                "functionname:python-layer-test",
-                "memorysize:256",
-                "cold_start:false",
             ],
         )
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,0 +1,60 @@
+import unittest
+
+from datadog_lambda.tags import parse_lambda_tags_from_arn, get_tags_from_context
+from tests.test_wrapper import get_mock_context
+
+
+class TestMetricTags(unittest.TestCase):
+    def test_parse_lambda_tags_from_arn(self):
+        self.assertListEqual(
+            parse_lambda_tags_from_arn(
+                "arn:aws:lambda:us-east-1:1234597598159:function:swf-hello-test"
+            ),
+            [
+                "region:us-east-1",
+                "account_id:1234597598159",
+                "functionname:swf-hello-test",
+            ],
+        )
+
+        self.assertListEqual(
+            parse_lambda_tags_from_arn(
+                "arn:aws:lambda:us-west-1:1234597598159:function:other-function:function-alias"
+            ),
+            [
+                "region:us-west-1",
+                "account_id:1234597598159",
+                "functionname:other-function",
+            ],
+        )
+
+    def test_get_tags_from_context(self):
+        cold_start_request_id = "first-request-id"
+        self.assertListEqual(
+            get_tags_from_context(
+                get_mock_context(aws_request_id=cold_start_request_id),
+                cold_start_request_id,
+            ),
+            [
+                "region:us-west-1",
+                "account_id:123457598159",
+                "functionname:python-layer-test",
+                "memorysize:256",
+                "cold_start:true",
+            ],
+        )
+
+        self.assertListEqual(
+            get_tags_from_context(
+                get_mock_context(aws_request_id="non-cold-start-request-id"),
+                cold_start_request_id,
+            ),
+            [
+                "region:us-west-1",
+                "account_id:123457598159",
+                "functionname:python-layer-test",
+                "memorysize:256",
+                "cold_start:false",
+            ],
+        )
+

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,38 +1,54 @@
 import os
 import unittest
-try:
-    from unittest.mock import patch, call, ANY
-except ImportError:
-    from mock import patch, call, ANY
 
-from datadog_lambda.wrapper import datadog_lambda_wrapper
+try:
+    from unittest.mock import patch, call, ANY, MagicMock
+except ImportError:
+    from mock import patch, call, ANY, MagicMock
+
+from datadog_lambda.wrapper import datadog_lambda_wrapper, cold_start_request_id
 from datadog_lambda.metric import lambda_metric
 
 
-class TestDatadogLambdaWrapper(unittest.TestCase):
+def get_mock_context(
+    aws_request_id="request-id-1",
+    memory_limit_in_mb="256",
+    invoked_function_arn="arn:aws:lambda:us-west-1:123457598159:function:python-layer-test",
+):
+    lambda_context = MagicMock()
+    lambda_context.aws_request_id = aws_request_id
+    lambda_context.memory_limit_in_mb = memory_limit_in_mb
+    lambda_context.invoked_function_arn = invoked_function_arn
+    return lambda_context
 
+
+class TestDatadogLambdaWrapper(unittest.TestCase):
     def setUp(self):
-        patcher = patch('datadog_lambda.metric.lambda_stats')
+        patcher = patch("datadog_lambda.metric.lambda_stats")
         self.mock_metric_lambda_stats = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = patch('datadog_lambda.wrapper.lambda_stats')
+        patcher = patch("datadog_lambda.wrapper.lambda_stats")
         self.mock_wrapper_lambda_stats = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = patch('datadog_lambda.wrapper.extract_dd_trace_context')
+        patcher = patch("datadog_lambda.wrapper.lambda_metric")
+        self.mock_wrapper_lambda_metric = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        patcher = patch("datadog_lambda.wrapper.extract_dd_trace_context")
         self.mock_extract_dd_trace_context = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = patch('datadog_lambda.wrapper.set_correlation_ids')
+        patcher = patch("datadog_lambda.wrapper.set_correlation_ids")
         self.mock_set_correlation_ids = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = patch('datadog_lambda.wrapper.inject_correlation_ids')
+        patcher = patch("datadog_lambda.wrapper.inject_correlation_ids")
         self.mock_inject_correlation_ids = patcher.start()
         self.addCleanup(patcher.stop)
 
-        patcher = patch('datadog_lambda.wrapper.patch_all')
+        patcher = patch("datadog_lambda.wrapper.patch_all")
         self.mock_patch_all = patcher.start()
         self.addCleanup(patcher.stop)
 
@@ -42,12 +58,12 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
             lambda_metric("test.metric", 100)
 
         lambda_event = {}
-        lambda_context = {}
-        lambda_handler(lambda_event, lambda_context)
 
-        self.mock_metric_lambda_stats.distribution.assert_has_calls([
-            call('test.metric', 100, timestamp=None, tags=ANY)
-        ])
+        lambda_handler(lambda_event, get_mock_context())
+
+        self.mock_metric_lambda_stats.distribution.assert_has_calls(
+            [call("test.metric", 100, timestamp=None, tags=ANY)]
+        )
         self.mock_wrapper_lambda_stats.flush.assert_called()
         self.mock_extract_dd_trace_context.assert_called_with(lambda_event)
         self.mock_set_correlation_ids.assert_called()
@@ -55,15 +71,14 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         self.mock_patch_all.assert_called()
 
     def test_datadog_lambda_wrapper_flush_to_log(self):
-        os.environ["DD_FLUSH_TO_LOG"] = 'True'
+        os.environ["DD_FLUSH_TO_LOG"] = "True"
 
         @datadog_lambda_wrapper
         def lambda_handler(event, context):
             lambda_metric("test.metric", 100)
 
         lambda_event = {}
-        lambda_context = {}
-        lambda_handler(lambda_event, lambda_context)
+        lambda_handler(lambda_event, get_mock_context())
 
         self.mock_metric_lambda_stats.distribution.assert_not_called()
         self.mock_wrapper_lambda_stats.flush.assert_not_called()
@@ -71,17 +86,118 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         del os.environ["DD_FLUSH_TO_LOG"]
 
     def test_datadog_lambda_wrapper_inject_correlation_ids(self):
-        os.environ["DD_LOGS_INJECTION"] = 'True'
+        os.environ["DD_LOGS_INJECTION"] = "True"
 
         @datadog_lambda_wrapper
         def lambda_handler(event, context):
             lambda_metric("test.metric", 100)
 
         lambda_event = {}
-        lambda_context = {}
-        lambda_handler(lambda_event, lambda_context)
+        lambda_handler(lambda_event, get_mock_context())
 
         self.mock_set_correlation_ids.assert_called()
         self.mock_inject_correlation_ids.assert_called()
 
         del os.environ["DD_LOGS_INJECTION"]
+
+    def test_invocations_metric(self):
+        @datadog_lambda_wrapper
+        def lambda_handler(event, context):
+            lambda_metric("test.metric", 100)
+
+        lambda_event = {}
+
+        lambda_handler(lambda_event, get_mock_context())
+
+        self.mock_wrapper_lambda_metric.assert_has_calls(
+            [
+                call(
+                    "aws.lambda.enhanced.invocations",
+                    1,
+                    tags=[
+                        "region:us-west-1",
+                        "account_id:123457598159",
+                        "functionname:python-layer-test",
+                        "memorysize:256",
+                        "cold_start:true",
+                    ],
+                )
+            ]
+        )
+
+    def test_errors_metric(self):
+        @datadog_lambda_wrapper
+        def lambda_handler(event, context):
+            raise RuntimeError()
+
+        lambda_event = {}
+
+        with self.assertRaises(RuntimeError):
+            lambda_handler(lambda_event, get_mock_context())
+
+        self.mock_wrapper_lambda_metric.assert_has_calls(
+            [
+                call(
+                    "aws.lambda.enhanced.invocations",
+                    1,
+                    tags=[
+                        "region:us-west-1",
+                        "account_id:123457598159",
+                        "functionname:python-layer-test",
+                        "memorysize:256",
+                        "cold_start:true",
+                    ],
+                ),
+                call(
+                    "aws.lambda.enhanced.errors",
+                    1,
+                    tags=[
+                        "region:us-west-1",
+                        "account_id:123457598159",
+                        "functionname:python-layer-test",
+                        "memorysize:256",
+                        "cold_start:true",
+                    ],
+                ),
+            ]
+        )
+
+    def test_cold_start_tag(self):
+        @datadog_lambda_wrapper
+        def lambda_handler(event, context):
+            lambda_metric("test.metric", 100)
+
+        lambda_event = {}
+        self.assertIsNone(cold_start_request_id)
+        lambda_handler(lambda_event, get_mock_context())
+
+        lambda_handler(
+            lambda_event, get_mock_context(aws_request_id="second-request-id")
+        )
+
+        self.mock_wrapper_lambda_metric.assert_has_calls(
+            [
+                call(
+                    "aws.lambda.enhanced.invocations",
+                    1,
+                    tags=[
+                        "region:us-west-1",
+                        "account_id:123457598159",
+                        "functionname:python-layer-test",
+                        "memorysize:256",
+                        "cold_start:true",
+                    ],
+                ),
+                call(
+                    "aws.lambda.enhanced.invocations",
+                    1,
+                    tags=[
+                        "region:us-west-1",
+                        "account_id:123457598159",
+                        "functionname:python-layer-test",
+                        "memorysize:256",
+                        "cold_start:false",
+                    ],
+                ),
+            ]
+        )

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -106,6 +106,8 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         del os.environ["DD_LOGS_INJECTION"]
 
     def test_invocations_metric(self):
+        os.environ["DD_ENHANCED_METRICS"] = "True"
+
         @datadog_lambda_wrapper
         def lambda_handler(event, context):
             lambda_metric("test.metric", 100)
@@ -129,7 +131,11 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
             ]
         )
 
+        del os.environ["DD_ENHANCED_METRICS"]
+
     def test_errors_metric(self):
+        os.environ["DD_ENHANCED_METRICS"] = "True"
+
         @datadog_lambda_wrapper
         def lambda_handler(event, context):
             raise RuntimeError()
@@ -164,7 +170,11 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
             ]
         )
 
+        del os.environ["DD_ENHANCED_METRICS"]
+
     def test_enhanced_metrics_cold_start_tag(self):
+        os.environ["DD_ENHANCED_METRICS"] = "True"
+
         @datadog_lambda_wrapper
         def lambda_handler(event, context):
             lambda_metric("test.metric", 100)
@@ -203,3 +213,18 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
                 ),
             ]
         )
+
+        del os.environ["DD_ENHANCED_METRICS"]
+
+    def test_no_enhanced_metrics_without_env_var(self):
+        @datadog_lambda_wrapper
+        def lambda_handler(event, context):
+            raise RuntimeError()
+
+        lambda_event = {}
+
+        with self.assertRaises(RuntimeError):
+            lambda_handler(lambda_event, get_mock_context())
+
+        self.mock_wrapper_lambda_metric.assert_not_called()
+


### PR DESCRIPTION
### What does this PR do?

Submits aws.lambda.enhanced.invocations and aws.lambda.enhanced.errors metrics from the wrapper.

### Testing Guidelines

Added and updated unit tests. 

Also updated some of the functions in the demo account that the metrics are reporting for the functions with the new version of the layer.