### PR TITLE
Tag enhanced metrics with runtime and memorysize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# Version 9 / 2019-11-04
+
+- Tag layer-generated `aws.lambda.enhanced.invocations` and `aws.lambda.enhanced.errors` enhanced metrics with `runtime` and `memorysize`
+
 # Version 8 / 2019-10-24
 
 - Remove vendored botocore requests patching since the package has been removed from the latest botocore

--- a/datadog_lambda/__init__.py
+++ b/datadog_lambda/__init__.py
@@ -1,6 +1,6 @@
 # The minor version corresponds to the Lambda layer version.
 # E.g.,, version 0.5.0 gets packaged into layer version 5.
-__version__ = '0.8.0'
+__version__ = '0.9.0'
 
 
 import os

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -14,8 +14,7 @@ import boto3
 from datadog import api
 from datadog.threadstats import ThreadStats
 from datadog_lambda import __version__
-from datadog_lambda.cold_start import get_cold_start_tag
-from datadog_lambda.tags import parse_lambda_tags_from_arn
+from datadog_lambda.tags import get_enhanced_metrics_tags
 
 
 ENHANCED_METRICS_NAMESPACE_PREFIX = "aws.lambda.enhanced"
@@ -82,7 +81,7 @@ def are_enhanced_metrics_enabled():
     return os.environ.get("DD_ENHANCED_METRICS", "false").lower() == "true"
 
 
-def submit_invocations_metric(lambda_arn):
+def submit_invocations_metric(lambda_context):
     """Increment aws.lambda.enhanced.invocations by 1
     """
     if not are_enhanced_metrics_enabled():
@@ -91,11 +90,11 @@ def submit_invocations_metric(lambda_arn):
     lambda_metric(
         "{}.invocations".format(ENHANCED_METRICS_NAMESPACE_PREFIX),
         1,
-        tags=parse_lambda_tags_from_arn(lambda_arn) + [get_cold_start_tag()],
+        tags=get_enhanced_metrics_tags(lambda_context),
     )
 
 
-def submit_errors_metric(lambda_arn):
+def submit_errors_metric(lambda_context):
     """Increment aws.lambda.enhanced.errors by 1
     """
     if not are_enhanced_metrics_enabled():
@@ -104,7 +103,7 @@ def submit_errors_metric(lambda_arn):
     lambda_metric(
         "{}.errors".format(ENHANCED_METRICS_NAMESPACE_PREFIX),
         1,
-        tags=parse_lambda_tags_from_arn(lambda_arn) + [get_cold_start_tag()],
+        tags=get_enhanced_metrics_tags(lambda_context),
     )
 
 

--- a/datadog_lambda/tags.py
+++ b/datadog_lambda/tags.py
@@ -1,3 +1,8 @@
+from platform import python_version_tuple
+
+from datadog_lambda.cold_start import get_cold_start_tag
+
+
 def parse_lambda_tags_from_arn(arn):
     """Generate the list of lambda tags based on the data in the arn
     Args:
@@ -17,4 +22,24 @@ def parse_lambda_tags_from_arn(arn):
         "region:{}".format(region),
         "account_id:{}".format(account_id),
         "functionname:{}".format(function_name),
+    ]
+
+
+def get_runtime_tag():
+    """Get the runtime tag from the current Python version
+    """
+    major_version, minor_version, _ = python_version_tuple()
+
+    return "runtime:python{major}.{minor}".format(
+        major=major_version, minor=minor_version
+    )
+
+
+def get_enhanced_metrics_tags(lambda_context):
+    """Get the list of tags to apply to enhanced metrics
+    """
+    return parse_lambda_tags_from_arn(lambda_context.invoked_function_arn) + [
+        get_cold_start_tag(),
+        "memorysize:{}".format(lambda_context.memory_limit_in_mb),
+        get_runtime_tag(),
     ]

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -61,7 +61,7 @@ class _LambdaDecorator(object):
         set_cold_start()
 
         try:
-            submit_invocations_metric(context.invoked_function_arn)
+            submit_invocations_metric(context)
             # Extract Datadog trace context from incoming requests
             extract_dd_trace_context(event)
 
@@ -82,7 +82,7 @@ class _LambdaDecorator(object):
         try:
             return self.func(event, context)
         except Exception:
-            submit_errors_metric(context.invoked_function_arn)
+            submit_errors_metric(context)
             raise
         finally:
             self._after(event, context)

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,38 +1,37 @@
 import os
 import unittest
+
 try:
     from unittest.mock import patch, call
 except ImportError:
     from mock import patch, call
 
-from datadog_lambda.metric import (
-    lambda_metric,
-    _format_dd_lambda_layer_tag,
-)
+from datadog_lambda.metric import lambda_metric, _format_dd_lambda_layer_tag
 
 
 class TestLambdaMetric(unittest.TestCase):
-
     def setUp(self):
-        patcher = patch('datadog_lambda.metric.lambda_stats')
+        patcher = patch("datadog_lambda.metric.lambda_stats")
         self.mock_metric_lambda_stats = patcher.start()
         self.addCleanup(patcher.stop)
 
     def test_lambda_metric_tagged_with_dd_lambda_layer(self):
-        lambda_metric('test', 1)
-        lambda_metric('test', 1, 123, [])
-        lambda_metric('test', 1, tags=['tag1:test'])
+        lambda_metric("test", 1)
+        lambda_metric("test", 1, 123, [])
+        lambda_metric("test", 1, tags=["tag1:test"])
         expected_tag = _format_dd_lambda_layer_tag()
-        self.mock_metric_lambda_stats.distribution.assert_has_calls([
-            call('test', 1, timestamp=None, tags=[expected_tag]),
-            call('test', 1, timestamp=123, tags=[expected_tag]),
-            call('test', 1, timestamp=None, tags=['tag1:test', expected_tag]),
-        ])
+        self.mock_metric_lambda_stats.distribution.assert_has_calls(
+            [
+                call("test", 1, timestamp=None, tags=[expected_tag]),
+                call("test", 1, timestamp=123, tags=[expected_tag]),
+                call("test", 1, timestamp=None, tags=["tag1:test", expected_tag]),
+            ]
+        )
 
     def test_lambda_metric_flush_to_log(self):
-        os.environ["DD_FLUSH_TO_LOG"] = 'True'
+        os.environ["DD_FLUSH_TO_LOG"] = "True"
 
-        lambda_metric('test', 1)
+        lambda_metric("test", 1)
         self.mock_metric_lambda_stats.distribution.assert_not_called()
 
         del os.environ["DD_FLUSH_TO_LOG"]

--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,37 +1,38 @@
 import os
 import unittest
-
 try:
     from unittest.mock import patch, call
 except ImportError:
     from mock import patch, call
 
-from datadog_lambda.metric import lambda_metric, _format_dd_lambda_layer_tag
+from datadog_lambda.metric import (
+    lambda_metric,
+    _format_dd_lambda_layer_tag,
+)
 
 
 class TestLambdaMetric(unittest.TestCase):
+
     def setUp(self):
-        patcher = patch("datadog_lambda.metric.lambda_stats")
+        patcher = patch('datadog_lambda.metric.lambda_stats')
         self.mock_metric_lambda_stats = patcher.start()
         self.addCleanup(patcher.stop)
 
     def test_lambda_metric_tagged_with_dd_lambda_layer(self):
-        lambda_metric("test", 1)
-        lambda_metric("test", 1, 123, [])
-        lambda_metric("test", 1, tags=["tag1:test"])
+        lambda_metric('test', 1)
+        lambda_metric('test', 1, 123, [])
+        lambda_metric('test', 1, tags=['tag1:test'])
         expected_tag = _format_dd_lambda_layer_tag()
-        self.mock_metric_lambda_stats.distribution.assert_has_calls(
-            [
-                call("test", 1, timestamp=None, tags=[expected_tag]),
-                call("test", 1, timestamp=123, tags=[expected_tag]),
-                call("test", 1, timestamp=None, tags=["tag1:test", expected_tag]),
-            ]
-        )
+        self.mock_metric_lambda_stats.distribution.assert_has_calls([
+            call('test', 1, timestamp=None, tags=[expected_tag]),
+            call('test', 1, timestamp=123, tags=[expected_tag]),
+            call('test', 1, timestamp=None, tags=['tag1:test', expected_tag]),
+        ])
 
     def test_lambda_metric_flush_to_log(self):
-        os.environ["DD_FLUSH_TO_LOG"] = "True"
+        os.environ["DD_FLUSH_TO_LOG"] = 'True'
 
-        lambda_metric("test", 1)
+        lambda_metric('test', 1)
         self.mock_metric_lambda_stats.distribution.assert_not_called()
 
         del os.environ["DD_FLUSH_TO_LOG"]

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,9 +1,19 @@
 import unittest
 
-from datadog_lambda.tags import parse_lambda_tags_from_arn
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from datadog_lambda.tags import parse_lambda_tags_from_arn, get_runtime_tag
 
 
 class TestMetricTags(unittest.TestCase):
+    def setUp(self):
+        patcher = patch("datadog_lambda.tags.python_version_tuple")
+        self.mock_python_version_tuple = patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_parse_lambda_tags_from_arn(self):
         self.assertListEqual(
             parse_lambda_tags_from_arn(
@@ -26,4 +36,11 @@ class TestMetricTags(unittest.TestCase):
                 "functionname:other-function",
             ],
         )
+
+    def test_get_runtime_tag(self):
+        self.mock_python_version_tuple.return_value = ("2", "7", "10")
+        self.assertEqual(get_runtime_tag(), "runtime:python2.7")
+
+        self.mock_python_version_tuple.return_value = ("3", "7", "2")
+        self.assertEqual(get_runtime_tag(), "runtime:python3.7")
 


### PR DESCRIPTION
### What does this PR do?

Adds runtime and memorysize tags to the enhanced invocations and errors metrics generated by the layer. 

### Motivation

Improve the usefulness of enhanced metrics

### Testing Guidelines

Added unit tests, currently testing the layer in the demo account