### PR TITLE
Remove botocore from the published layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,7 @@ RUN pip install . -t ./python/lib/$runtime/site-packages
 
 # Remove *.pyc files
 RUN find ./python/lib/$runtime/site-packages -name \*.pyc -delete
+
+# Remove botocore (40MB) to reduce package size. aws-xray-sdk
+# installs it, while it's already provided by the Lambda Runtime.
+RUN rm -rf ./python/lib/$runtime/site-packages/botocore*

--- a/setup.py
+++ b/setup.py
@@ -32,13 +32,13 @@ setup(
         'ddtrace==0.28.0',
         'wrapt==1.11.1',
         'setuptools==40.8.0',
-        'boto3==1.9.160'
     ],
     extras_require={
         'dev': [
             'nose2==0.9.1',
             'flake8==3.7.7',
-            'requests==2.21.0'
+            'requests==2.21.0',
+            'boto3==1.9.160',
         ]
     }
 )

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -43,4 +43,3 @@ class TestMetricTags(unittest.TestCase):
 
         self.mock_python_version_tuple.return_value = ("3", "7", "2")
         self.assertEqual(get_runtime_tag(), "runtime:python3.7")
-

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -242,4 +242,3 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
             lambda_handler(lambda_event, get_mock_context())
 
         self.mock_lambda_metric.assert_not_called()
-


### PR DESCRIPTION
### What does this PR do?

Remove botocore (40MB) to reduce package size (before: 50MB, after: 10MB). `aws-xray-sdk`  installs `botocore`, but it's safe to cut it out from the layer zip, as it's already provided by the Lambda Runtime.
