### PR TITLE
Allow kwargs in lambda handlers

### DIFF
--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -57,7 +57,7 @@ class _LambdaDecorator(object):
         patch_all()
         logger.debug("datadog_lambda_wrapper initialized")
 
-    def _before(self, event, context, **kwargs):
+    def _before(self, event, context):
         set_cold_start()
         try:
             submit_invocations_metric(context)
@@ -69,7 +69,7 @@ class _LambdaDecorator(object):
         except Exception:
             traceback.print_exc()
 
-    def _after(self, event, context, **kwargs):
+    def _after(self, event, context):
         try:
             if not self.flush_to_log:
                 lambda_stats.flush(float("inf"))
@@ -77,14 +77,14 @@ class _LambdaDecorator(object):
             traceback.print_exc()
 
     def __call__(self, event, context, **kwargs):
-        self._before(event, context, **kwargs)
+        self._before(event, context)
         try:
             return self.func(event, context, **kwargs)
         except Exception:
             submit_errors_metric(context)
             raise
         finally:
-            self._after(event, context, **kwargs)
+            self._after(event, context)
 
 
 datadog_lambda_wrapper = _LambdaDecorator

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -57,9 +57,8 @@ class _LambdaDecorator(object):
         patch_all()
         logger.debug("datadog_lambda_wrapper initialized")
 
-    def _before(self, event, context):
+    def _before(self, event, context, **kwargs):
         set_cold_start()
-
         try:
             submit_invocations_metric(context)
             # Extract Datadog trace context from incoming requests
@@ -70,22 +69,22 @@ class _LambdaDecorator(object):
         except Exception:
             traceback.print_exc()
 
-    def _after(self, event, context):
+    def _after(self, event, context, **kwargs):
         try:
             if not self.flush_to_log:
                 lambda_stats.flush(float("inf"))
         except Exception:
             traceback.print_exc()
 
-    def __call__(self, event, context):
-        self._before(event, context)
+    def __call__(self, event, context, **kwargs):
+        self._before(event, context, **kwargs)
         try:
-            return self.func(event, context)
+            return self.func(event, context, **kwargs)
         except Exception:
             submit_errors_metric(context)
             raise
         finally:
-            self._after(event, context)
+            self._after(event, context, **kwargs)
 
 
 datadog_lambda_wrapper = _LambdaDecorator

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.


### PR DESCRIPTION
### What does this PR do?

Allows `kwargs` in lambda handlers. 

### Motivation

Our serverless project has `kwargs` in the lambda handlers to make testing easier. If we add the datadog lambda wrapper, the tests break.  

Example of `kwargs` in a lambda handler:
```python
SQS = boto3.client('sqs', region_name='us-east-1')
DYNAMO_CLIENT = boto3.resource('dynamodb', region_name='us-east-1')
LOGGER = setup_logger()

def lambda_handler(event, context, logger=LOGGER, sqs_client=SQS, dynamodb_client=DYNAMO_CLIENT):
    pass
```
### Testing Guidelines

I ran `./scripts/run_tests.sh` and all tests were OK. I also installed locally this version of the package on my project and my tests now pass. 

### Additional Notes

I also modified the `run_tests.sh` shebang to `#!/bin/bash` since the `PYTHON_VERSIONS` array was declared with bash-specific syntax and trying to run `./scripts/run_tests.sh` with `sh` failed.
