### PR TITLE
Feature/python 3 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,3 +53,8 @@ workflows:
     jobs:
       - verify_build:
           python: "3.7"
+
+  python-v3.8:
+    jobs:
+      - verify_build:
+          python: "3.8"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 [![CircleCI](https://img.shields.io/circleci/build/github/DataDog/datadog-lambda-layer-python)](https://circleci.com/gh/DataDog/datadog-lambda-layer-python)
 [![PyPI](https://img.shields.io/pypi/v/datadog-lambda)](https://pypi.org/project/datadog-lambda/)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/datadog-lambda)
 [![Slack](https://img.shields.io/badge/slack-%23serverless-blueviolet?logo=slack)](https://datadoghq.slack.com/channels/serverless/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DataDog/datadog-lambda-layer-python/blob/master/LICENSE)
 
-Datadog Lambda Layer for Python (2.7, 3.6 and 3.7) enables custom metric submission from AWS Lambda functions, and distributed tracing between serverful and serverless environments.
+Datadog Lambda Layer for Python (2.7, 3.6, 3.7 and 3.8) enables custom metric submission from AWS Lambda functions, and distributed tracing between serverful and serverless environments.
 
 ## Installation
 
@@ -15,7 +16,13 @@ Datadog Lambda Layer can be added to a Lambda function via AWS Lambda console, [
 arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<PYTHON_RUNTIME>:<VERSION>
 ```
 
-Replace `<AWS_REGION>` with the AWS region where your Lambda function is published to. Replace `<PYTHON_RUNTIME>` with `Datadog-Python27` with `Datadog-Python36` or `Datadog-Python37` that matches your Lambda's Python runtime. Replace `<VERSION>` with the latest layer version that can be found from [CHANGELOG](CHANGELOG.md). For example,
+Replace `<AWS_REGION>` with the AWS region where your Lambda function is published to. Replace `<PYTHON_RUNTIME>` with one of the following that matches your Lambda's Python runtime:
+- `Datadog-Python27`
+- `Datadog-Python36`
+- `Datadog-Python37`
+- `Datadog-Python38`
+
+Replace `<VERSION>` with the latest layer version that can be found from [CHANGELOG](CHANGELOG.md). For example,
 
 ```
 arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:1

--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -10,7 +10,7 @@ set -e
 
 LAYER_DIR=".layers"
 LAYER_FILES_PREFIX="datadog_lambda_py"
-PYTHON_VERSIONS=("2.7" "3.6" "3.7")
+PYTHON_VERSIONS=("2.7" "3.6" "3.7" "3.8")
 
 function make_path_absolute {
     echo "$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"

--- a/scripts/list_layers.sh
+++ b/scripts/list_layers.sh
@@ -8,7 +8,7 @@
 # Lists most recent layers ARNs across regions to STDOUT
 # Optionals args: [layer-name] [region]
 
-LAYER_NAMES=("Datadog-Python27" "Datadog-Python36" "Datadog-Python37")
+LAYER_NAMES=("Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
 AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1)
 
 # Check region arg

--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -13,9 +13,9 @@ set -e
 # Makes sure any subprocesses will be terminated with this process
 trap "pkill -P $$; exit 1;" INT
 
-PYTHON_VERSIONS_FOR_AWS_CLI=("python2.7" "python3.6" "python3.7")
-LAYER_PATHS=(".layers/datadog_lambda_py2.7.zip" ".layers/datadog_lambda_py3.6.zip" ".layers/datadog_lambda_py3.7.zip")
-AVAILABLE_LAYER_NAMES=("Datadog-Python27" "Datadog-Python36" "Datadog-Python37")
+PYTHON_VERSIONS_FOR_AWS_CLI=("python2.7" "python3.6" "python3.7" "python3.8")
+LAYER_PATHS=(".layers/datadog_lambda_py2.7.zip" ".layers/datadog_lambda_py3.6.zip" ".layers/datadog_lambda_py3.7.zip" ".layers/datadog_lambda_py3.8.zip")
+AVAILABLE_LAYER_NAMES=("Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
 AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1)
 
 # Check that the layer files exist

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -8,7 +8,7 @@
 # Run unit tests in Docker
 set -e
 
-PYTHON_VERSIONS=("2.7" "3.6" "3.7")
+PYTHON_VERSIONS=("2.7" "3.6" "3.7" "3.8")
 
 for python_version in "${PYTHON_VERSIONS[@]}"
 do

--- a/setup.py
+++ b/setup.py
@@ -28,18 +28,18 @@ setup(
     packages=['datadog_lambda'],
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4',
     install_requires=[
-        'aws-xray-sdk==2.4.2',
+        'aws-xray-sdk==2.4.3',
         'datadog==0.32.0',
-        'ddtrace==0.30.2',
-        'wrapt==1.11.1',
-        'setuptools==41.6.0',
+        'ddtrace==0.31.0',
+        'wrapt==1.11.2',
+        'setuptools==42.0.2',
     ],
     extras_require={
         'dev': [
             'nose2==0.9.1',
-            'flake8==3.7.7',
-            'requests==2.21.0',
-            'boto3==1.10.17',
+            'flake8==3.7.9',
+            'requests==2.22.0',
+            'boto3==1.10.33',
         ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     keywords='datadog aws lambda layer',
     packages=['datadog_lambda'],


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-python/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?
- Adds support for Python 3.8 runtime
- Updates dependencies to latest versions

### Motivation

- AWS has recently released the lambda native Python 3.8 runtime

### Testing Guidelines

`./scripts/run_tests.sh`

### Additional Notes

All tests have passed, included the dependency updates since they would go out with the next layer publish and low risk of breaking changes.

Closes #31 
