### PR TITLE
Fix / Remove Python 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,6 @@ jobs:
           key: v1-dependencies-<< parameters.python >>-{{ checksum "setup.py" }}
 
 workflows:
-  python-v2.7:
-    jobs:
-      - verify_build:
-          python: "2.7"
-
   python-v3.6:
     jobs:
       - verify_build:

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 Datadog datadog-lambda-layer-python
-Copyright 2019 Datadog, Inc.
+Copyright 2019-2020 Datadog, Inc.
 
 This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 Datadog Lambda Layer for Python (3.6, 3.7 and 3.8) enables custom metric submission from AWS Lambda functions, and distributed tracing between serverful and serverless environments.
 
+### Note - 2.7 End of Support
+
+With the release of Datadog Agent 7, the latest major release at time of writing, Python 2 support has been removed with only Python 3 supported going forward. Python 2 is reaching its end of life on January 1, 2020, so migrating to Python 3 is critical to ensure your services can continue to work as expected. Python 2 functionality is available in layers `v11` and earlier.
+
 ## Installation
 
 Datadog Lambda Layer can be added to a Lambda function via AWS Lambda console, [AWS CLI](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html#configuration-layers-using) or [Serverless Framework](https://serverless.com/framework/docs/providers/aws/guide/layers/#using-your-layers) using the following ARN.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Slack](https://img.shields.io/badge/slack-%23serverless-blueviolet?logo=slack)](https://datadoghq.slack.com/channels/serverless/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](https://github.com/DataDog/datadog-lambda-layer-python/blob/master/LICENSE)
 
-Datadog Lambda Layer for Python (2.7, 3.6, 3.7 and 3.8) enables custom metric submission from AWS Lambda functions, and distributed tracing between serverful and serverless environments.
+Datadog Lambda Layer for Python (3.6, 3.7 and 3.8) enables custom metric submission from AWS Lambda functions, and distributed tracing between serverful and serverless environments.
 
 ## Installation
 
@@ -17,7 +17,6 @@ arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<PYTHON_RUNTIME>:<VERSION
 ```
 
 Replace `<AWS_REGION>` with the AWS region where your Lambda function is published to. Replace `<PYTHON_RUNTIME>` with one of the following that matches your Lambda's Python runtime:
-- `Datadog-Python27`
 - `Datadog-Python36`
 - `Datadog-Python37`
 - `Datadog-Python38`
@@ -156,7 +155,7 @@ Note, the Datadog Lambda Layer is only needed to enable _distributed_ tracing be
 
 ### Patching
 
-By default, widely used HTTP client libraries, such as `requests`, `urllib2` and `urllib.request` are patched automatically to inject Datadog trace context into outgoing requests.
+By default, widely used HTTP client libraries, such as `requests`, and `urllib.request` are patched automatically to inject Datadog trace context into outgoing requests.
 
 You can also manually retrieve the Datadog trace context (i.e., http headers in a Python dict) and inject it to request headers when needed.
 

--- a/README.md
+++ b/README.md
@@ -271,4 +271,4 @@ If you find an issue with this package and have a fix, please feel free to open 
 
 Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 
-This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2019 Datadog, Inc.
+This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2019-2020 Datadog, Inc.

--- a/datadog_lambda/cold_start.py
+++ b/datadog_lambda/cold_start.py
@@ -22,4 +22,4 @@ def is_cold_start():
 def get_cold_start_tag():
     """Returns the cold start tag to be used in metrics
     """
-    return "cold_start:{}".format(str(is_cold_start()).lower())
+    return f"cold_start:{str(is_cold_start()).lower()}"

--- a/datadog_lambda/constants.py
+++ b/datadog_lambda/constants.py
@@ -1,7 +1,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2019 Datadog, Inc.
+# Copyright 2019-2020 Datadog, Inc.
 
 
 # Datadog trace sampling priority

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -29,8 +29,8 @@ def _format_dd_lambda_layer_tag():
     """
     Formats the dd_lambda_layer tag, e.g., 'dd_lambda_layer:datadog-python27_1'
     """
-    runtime = "python{}{}".format(sys.version_info[0], sys.version_info[1])
-    return "dd_lambda_layer:datadog-{}_{}".format(runtime, __version__)
+    runtime = f"python{sys.version_info[0]}{sys.version_info[1]}"
+    return f"dd_lambda_layer:datadog-{runtime}_{__version__}"
 
 
 def _tag_dd_lambda_layer(tags):
@@ -88,7 +88,7 @@ def submit_invocations_metric(lambda_context):
         return
 
     lambda_metric(
-        "{}.invocations".format(ENHANCED_METRICS_NAMESPACE_PREFIX),
+        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.invocations",
         1,
         tags=get_enhanced_metrics_tags(lambda_context),
     )
@@ -101,7 +101,7 @@ def submit_errors_metric(lambda_context):
         return
 
     lambda_metric(
-        "{}.errors".format(ENHANCED_METRICS_NAMESPACE_PREFIX),
+        f"{ENHANCED_METRICS_NAMESPACE_PREFIX}.errors",
         1,
         tags=get_enhanced_metrics_tags(lambda_context),
     )

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -27,7 +27,7 @@ lambda_stats.start()
 
 def _format_dd_lambda_layer_tag():
     """
-    Formats the dd_lambda_layer tag, e.g., 'dd_lambda_layer:datadog-python27_1'
+    Formats the dd_lambda_layer tag, e.g., 'dd_lambda_layer:datadog-python37_1'
     """
     runtime = f"python{sys.version_info[0]}{sys.version_info[1]}"
     return f"dd_lambda_layer:datadog-{runtime}_{__version__}"

--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -1,7 +1,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2019 Datadog, Inc.
+# Copyright 2019-2020 Datadog, Inc.
 
 import os
 import sys

--- a/datadog_lambda/patch.py
+++ b/datadog_lambda/patch.py
@@ -1,7 +1,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2019 Datadog, Inc.
+# Copyright 2019-2020 Datadog, Inc.
 
 import logging
 

--- a/datadog_lambda/tags.py
+++ b/datadog_lambda/tags.py
@@ -19,20 +19,18 @@ def parse_lambda_tags_from_arn(arn):
     _, _, _, region, account_id, _, function_name = split_arn
 
     return [
-        "region:{}".format(region),
-        "account_id:{}".format(account_id),
-        "functionname:{}".format(function_name),
+        f"region:{region}",
+        f"account_id:{account_id}",
+        f"functionname:{function_name}",
     ]
 
 
 def get_runtime_tag():
     """Get the runtime tag from the current Python version
     """
-    major_version, minor_version, _ = python_version_tuple()
+    major, minor, _ = python_version_tuple()
 
-    return "runtime:python{major}.{minor}".format(
-        major=major_version, minor=minor_version
-    )
+    return f"runtime:python{major}.{minor}"
 
 
 def get_enhanced_metrics_tags(lambda_context):
@@ -40,6 +38,6 @@ def get_enhanced_metrics_tags(lambda_context):
     """
     return parse_lambda_tags_from_arn(lambda_context.invoked_function_arn) + [
         get_cold_start_tag(),
-        "memorysize:{}".format(lambda_context.memory_limit_in_mb),
+        f"memorysize:{lambda_context.memory_limit_in_mb}",
         get_runtime_tag(),
     ]

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -1,7 +1,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2019 Datadog, Inc.
+# Copyright 2019-2020 Datadog, Inc.
 
 import logging
 

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -1,7 +1,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2019 Datadog, Inc.
+# Copyright 2019-2020 Datadog, Inc.
 
 import os
 import logging

--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -3,7 +3,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2019 Datadog, Inc.
+# Copyright 2019-2020 Datadog, Inc.
 
 # Builds Datadogpy layers for lambda functions, using Docker
 set -e

--- a/scripts/build_layers.sh
+++ b/scripts/build_layers.sh
@@ -10,7 +10,7 @@ set -e
 
 LAYER_DIR=".layers"
 LAYER_FILES_PREFIX="datadog_lambda_py"
-PYTHON_VERSIONS=("2.7" "3.6" "3.7" "3.8")
+PYTHON_VERSIONS=("3.6" "3.7" "3.8")
 
 function make_path_absolute {
     echo "$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"

--- a/scripts/list_layers.sh
+++ b/scripts/list_layers.sh
@@ -8,7 +8,7 @@
 # Lists most recent layers ARNs across regions to STDOUT
 # Optionals args: [layer-name] [region]
 
-LAYER_NAMES=("Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
+LAYER_NAMES=("Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
 AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1)
 
 # Check region arg

--- a/scripts/list_layers.sh
+++ b/scripts/list_layers.sh
@@ -3,7 +3,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2019 Datadog, Inc.
+# Copyright 2019-2020 Datadog, Inc.
 
 # Lists most recent layers ARNs across regions to STDOUT
 # Optionals args: [layer-name] [region]

--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -13,8 +13,8 @@ set -e
 # Makes sure any subprocesses will be terminated with this process
 trap "pkill -P $$; exit 1;" INT
 
-PYTHON_VERSIONS_FOR_AWS_CLI=("python2.7" "python3.6" "python3.7" "python3.8")
-LAYER_PATHS=(".layers/datadog_lambda_py2.7.zip" ".layers/datadog_lambda_py3.6.zip" ".layers/datadog_lambda_py3.7.zip" ".layers/datadog_lambda_py3.8.zip")
+PYTHON_VERSIONS_FOR_AWS_CLI=("python3.6" "python3.7" "python3.8")
+LAYER_PATHS=(".layers/datadog_lambda_py3.6.zip" ".layers/datadog_lambda_py3.7.zip" ".layers/datadog_lambda_py3.8.zip")
 AVAILABLE_LAYER_NAMES=("Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
 AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1)
 

--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -3,7 +3,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2019 Datadog, Inc.
+# Copyright 2019-2020 Datadog, Inc.
 
 # Publish the datadog python lambda layer across regions, using the AWS CLI
 # Usage: publish_layer.sh [region] [layer]

--- a/scripts/pypi.sh
+++ b/scripts/pypi.sh
@@ -3,7 +3,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2019 Datadog, Inc.
+# Copyright 2019-2020 Datadog, Inc.
 
 # Builds the lambda layer and upload to Pypi
 set -e

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -8,7 +8,7 @@
 # Run unit tests in Docker
 set -e
 
-PYTHON_VERSIONS=("2.7" "3.6" "3.7" "3.8")
+PYTHON_VERSIONS=("3.6" "3.7" "3.8")
 
 for python_version in "${PYTHON_VERSIONS[@]}"
 do

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -3,7 +3,7 @@
 # Unless explicitly stated otherwise all files in this repository are licensed
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
-# Copyright 2019 Datadog, Inc.
+# Copyright 2019-2020 Datadog, Inc.
 
 # Run unit tests in Docker
 set -e

--- a/setup.py
+++ b/setup.py
@@ -28,17 +28,17 @@ setup(
     python_requires='>=3.6.*, <4',
     install_requires=[
         'aws-xray-sdk==2.4.3',
-        'datadog==0.32.0',
+        'datadog==0.33.0',
         'ddtrace==0.31.0',
         'wrapt==1.11.2',
-        'setuptools==42.0.2',
+        'setuptools==44.0.0',
     ],
     extras_require={
         'dev': [
             'nose2==0.9.1',
             'flake8==3.7.9',
             'requests==2.22.0',
-            'boto3==1.10.33',
+            'boto3==1.10.46',
         ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -19,14 +19,13 @@ setup(
     author='Datadog, Inc.',
     author_email='dev@datadoghq.com',
     classifiers=[
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
     keywords='datadog aws lambda layer',
     packages=['datadog_lambda'],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4',
+    python_requires='>=3.6.*, <4',
     install_requires=[
         'aws-xray-sdk==2.4.3',
         'datadog==0.32.0',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,13 @@ setup(
     url='https://github.com/DataDog/datadog-lambda-layer-python',
     author='Datadog, Inc.',
     author_email='dev@datadoghq.com',
+    license='Apache 2.0',
     classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -28,6 +34,7 @@ setup(
     python_requires='>=3.6.*, <4',
     install_requires=[
         'aws-xray-sdk==2.4.3',
+        'boto3==1.10.46',
         'datadog==0.33.0',
         'ddtrace==0.31.0',
         'wrapt==1.11.2',
@@ -37,8 +44,7 @@ setup(
         'dev': [
             'nose2==0.9.1',
             'flake8==3.7.9',
-            'requests==2.22.0',
-            'boto3==1.10.46',
+            'requests==2.22.0'
         ]
     }
 )

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 try:
     from unittest.mock import patch
@@ -26,10 +25,7 @@ class TestPatchHTTPClients(unittest.TestCase):
 
     def test_patch_httplib(self):
         _patch_httplib()
-        if sys.version_info >= (3, 0, 0):
-            import urllib.request as urllib
-        else:
-            import urllib2 as urllib
+        import urllib.request as urllib
         urllib.urlopen("https://www.datadoghq.com/")
         self.mock_get_dd_trace_context.assert_called()
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -1,9 +1,5 @@
 import unittest
-
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 from datadog_lambda.tags import parse_lambda_tags_from_arn, get_runtime_tag
 
@@ -38,8 +34,5 @@ class TestMetricTags(unittest.TestCase):
         )
 
     def test_get_runtime_tag(self):
-        self.mock_python_version_tuple.return_value = ("2", "7", "10")
-        self.assertEqual(get_runtime_tag(), "runtime:python2.7")
-
         self.mock_python_version_tuple.return_value = ("3", "7", "2")
         self.assertEqual(get_runtime_tag(), "runtime:python3.7")

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,8 +1,5 @@
 import unittest
-try:
-    from unittest.mock import MagicMock, patch
-except ImportError:
-    from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from ddtrace.helpers import get_correlation_ids
 from datadog_lambda.constants import (

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,10 +1,6 @@
 import os
 import unittest
-
-try:
-    from unittest.mock import patch, call, ANY, MagicMock
-except ImportError:
-    from mock import patch, call, ANY, MagicMock
+from unittest.mock import patch, call, ANY, MagicMock
 
 from datadog_lambda.wrapper import datadog_lambda_wrapper
 from datadog_lambda.metric import lambda_metric
@@ -59,7 +55,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
 
         patcher = patch("datadog_lambda.tags.python_version_tuple")
         self.mock_python_version_tuple = patcher.start()
-        self.mock_python_version_tuple.return_value = ("2", "7", "10")
+        self.mock_python_version_tuple.return_value = ("3", "7", "2")
         self.addCleanup(patcher.stop)
 
     def test_datadog_lambda_wrapper(self):
@@ -132,7 +128,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
                         "functionname:python-layer-test",
                         "cold_start:true",
                         "memorysize:256",
-                        "runtime:python2.7",
+                        "runtime:python3.7",
                     ],
                 )
             ]
@@ -163,7 +159,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
                         "functionname:python-layer-test",
                         "cold_start:true",
                         "memorysize:256",
-                        "runtime:python2.7",
+                        "runtime:python3.7",
                     ],
                 ),
                 call(
@@ -175,7 +171,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
                         "functionname:python-layer-test",
                         "cold_start:true",
                         "memorysize:256",
-                        "runtime:python2.7",
+                        "runtime:python3.7",
                     ],
                 ),
             ]
@@ -211,7 +207,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
                         "functionname:python-layer-test",
                         "cold_start:true",
                         "memorysize:256",
-                        "runtime:python2.7",
+                        "runtime:python3.7",
                     ],
                 ),
                 call(
@@ -223,7 +219,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
                         "functionname:python-layer-test",
                         "cold_start:false",
                         "memorysize:256",
-                        "runtime:python2.7",
+                        "runtime:python3.7",
                     ],
                 ),
             ]


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-python/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

- Remove Python 2.7 due to end of life and the release of Datadog agent 7 which drops support for 2.7
- Replace use of `.fortmat(x)` with f-strings (https://twitter.com/raymondh/status/1205969258800275456) supported in 3.6+
- Move boto3 to required dependency due to `metrics.py` direct import, add additional metadata to `setup.py`
- Bump dependency versions to latest
- Update copyright declarations to include 2020
- Add note on Python 2 end of support for layer

### Motivation

Python 2.7 has come and gone - it was a faithful runtime that served well for many. Now its time to move forward and take advantage of modern improvements that have been held back due to 2.7 support, and shed the technical overhead of trying to support two major runtimes that have diverged significantly. This pull request drops that old baggage, and starts to unlock improvements from 3.6+

### Testing Guidelines

How did you test this pull request?

```bash
$ ./scripts/run_tests.sh
```

All tests passed successfully

### Additional Notes

Anything else we should know when reviewing?

Submitted a PR on `datadogpy` as well for same change https://github.com/DataDog/datadogpy/pull/507
