### PR TITLE
check api_key had been set before setting the value from env

### DIFF
--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -108,19 +108,20 @@ def submit_errors_metric(lambda_context):
 
 
 # Set API Key and Host in the module, so they only set once per container
-DD_API_KEY_SECRET_ARN = os.environ.get("DD_API_KEY_SECRET_ARN", "")
-DD_KMS_API_KEY = os.environ.get("DD_KMS_API_KEY", "")
-DD_API_KEY = os.environ.get("DD_API_KEY", os.environ.get("DATADOG_API_KEY", ""))
-if DD_API_KEY_SECRET_ARN:
-    api._api_key = boto3.client("secretsmanager").get_secret_value(
-        SecretId=DD_API_KEY_SECRET_ARN
-    )["SecretString"]
-elif DD_KMS_API_KEY:
-    api._api_key = boto3.client("kms").decrypt(
-        CiphertextBlob=base64.b64decode(DD_KMS_API_KEY)
-    )["Plaintext"]
-else:
-    api._api_key = DD_API_KEY
+if not api._api_key:
+    DD_API_KEY_SECRET_ARN = os.environ.get("DD_API_KEY_SECRET_ARN", "")
+    DD_KMS_API_KEY = os.environ.get("DD_KMS_API_KEY", "")
+    DD_API_KEY = os.environ.get("DD_API_KEY", os.environ.get("DATADOG_API_KEY", ""))
+    if DD_API_KEY_SECRET_ARN:
+        api._api_key = boto3.client("secretsmanager").get_secret_value(
+            SecretId=DD_API_KEY_SECRET_ARN
+        )["SecretString"]
+    elif DD_KMS_API_KEY:
+        api._api_key = boto3.client("kms").decrypt(
+            CiphertextBlob=base64.b64decode(DD_KMS_API_KEY)
+        )["Plaintext"]
+    else:
+        api._api_key = DD_API_KEY
 logger.debug("Setting DATADOG_API_KEY of length %d", len(api._api_key))
 
 # Set DATADOG_HOST, to send data to a non-default Datadog datacenter


### PR DESCRIPTION
*Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-python/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Lambda metric will tries to get `DD_KEY_API` value from 3 different places when `lambda_metric` imports and set its value into `api._api_key` in Datadog library.  However, I received an empty string as result when I tries to import `lambda_metric` that describe in doc
```
https://github.com/DataDog/datadog-lambda-layer-python#environment-variables 
from datadog import api
api._api_key = "MY_API_KEY"
```

This PR is intend to check on `_api_key` before setting it.

### Motivation

What inspired you to submit this pull request?

allow user to overwrite API Key at runtime without side effect

### Testing Guidelines

How did you test this pull request?

- [ ] `_api_key` will preserve when `Datadog.lambda_metric` imports if we had previously set it in `Datadog.api._api_key` 

### Additional Notes

Anything else we should know when reviewing?

N/A