### PR TITLE
Enable log trace context injection by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,9 +235,9 @@ If your Lambda function is triggered by API Gateway via [the non-proxy integrati
 If your Lambda function is deployed by the Serverless Framework, such a mapping template gets created by default.
 
 ## Log and Trace Correlations
-By default, the Datadog trace id gets automatically injected into the logs for correlation, if using `console` or a logging library supported for [automatic](https://docs.datadoghq.com/tracing/connect_logs_and_traces/?tab=nodejs#automatic-trace-id-injection)  trace id injection.
+By default, the Datadog trace id gets automatically injected into the logs for correlation, if using the AWS provided `LambdaLoggerHandler`.
 
-See instructions for [manual](https://docs.datadoghq.com/tracing/connect_logs_and_traces/?tab=nodejs#manual-trace-id-injection) trace id injection, if using other logging libraries. If you use a custom logger handler to log in json, you can manually inject the ids using the helper function `get_correlation_ids`.
+If you use a custom logger handler to log in json, you can manually inject the ids using the helper function `get_correlation_ids`.
 
 Set the environment variable `DD_LOGS_INJECTION` to `false` to disable this feature.
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ If your Lambda function is deployed by the Serverless Framework, such a mapping 
 ## Log and Trace Correlations
 By default, the Datadog trace id gets automatically injected into the logs for correlation, if using the standard python `logging` library.
 
-If you use a custom logger handler to log in json, you can manually inject the ids using the helper function `get_correlation_ids`.
+If you use a custom logger handler to log in json, you can inject the ids using the helper function `get_correlation_ids` [manually](https://docs.datadoghq.com/tracing/connect_logs_and_traces/?tab=python#manual-trace-id-injection).
 
 Set the environment variable `DD_LOGS_INJECTION` to `false` to disable this feature.
 

--- a/README.md
+++ b/README.md
@@ -235,10 +235,11 @@ If your Lambda function is triggered by API Gateway via [the non-proxy integrati
 If your Lambda function is deployed by the Serverless Framework, such a mapping template gets created by default.
 
 ## Log and Trace Correlations
+By default, the Datadog trace id gets automatically injected into the logs for correlation, if using `console` or a logging library supported for [automatic](https://docs.datadoghq.com/tracing/connect_logs_and_traces/?tab=nodejs#automatic-trace-id-injection)  trace id injection.
 
-To connect logs and traces, set the environment variable `DD_LOGS_INJECTION` to `True`. The log format of the AWS provided `LambdaLoggerHandler` will be overridden to inject `dd.trace_id` and `dd.span_id`. The default Datadog lambda log integration pipeline will automatically parse them and map the `dd.trace_id` into the reserved attribute [trace_id](https://docs.datadoghq.com/logs/processing/#trace-id-attribute).
+See instructions for [manual](https://docs.datadoghq.com/tracing/connect_logs_and_traces/?tab=nodejs#manual-trace-id-injection) trace id injection, if using other logging libraries. If you use a custom logger handler to log in json, you can manually inject the ids using the helper function `get_correlation_ids`.
 
-If you use a custom logger handler to log in json, you can manually inject the ids using the helper function `get_correlation_ids`.
+Set the environment variable `DD_LOGS_INJECTION` to `false` to disable this feature.
 
 ```python
 from datadog_lambda.wrapper import datadog_lambda_wrapper

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If your Lambda function powers a performance-critical task (e.g., a consumer-fac
 
 - DD_FLUSH_TO_LOG
 
-To connect logs and traces, set the environment variable below to `True`. The default format of the AWS provided `LambdaLoggerHandler` will be overridden to inject `dd.trace_id` and `dd.span_id`. The default Datadog lambda log integration pipeline will automatically parse them and map the `dd.trace_id` into the reserved [trace_id attribute](https://docs.datadoghq.com/logs/processing/#trace-id-attribute). Defaults to true.
+Inject Datadog trace id into logs for [correlation](https://docs.datadoghq.com/tracing/connect_logs_and_traces/?tab=python). Defaults to true.
 
 - DD_LOGS_INJECTION
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If your Lambda function powers a performance-critical task (e.g., a consumer-fac
 
 - DD_FLUSH_TO_LOG
 
-To connect logs and traces, set the environment variable below to `True`. The default format of the AWS provided `LambdaLoggerHandler` will be overridden to inject `dd.trace_id` and `dd.span_id`. The default Datadog lambda log integration pipeline will automatically parse them and map the `dd.trace_id` into the reserved [trace_id attribute](https://docs.datadoghq.com/logs/processing/#trace-id-attribute).
+To connect logs and traces, set the environment variable below to `True`. The default format of the AWS provided `LambdaLoggerHandler` will be overridden to inject `dd.trace_id` and `dd.span_id`. The default Datadog lambda log integration pipeline will automatically parse them and map the `dd.trace_id` into the reserved [trace_id attribute](https://docs.datadoghq.com/logs/processing/#trace-id-attribute). Defaults to true.
 
 - DD_LOGS_INJECTION
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ If your Lambda function is triggered by API Gateway via [the non-proxy integrati
 If your Lambda function is deployed by the Serverless Framework, such a mapping template gets created by default.
 
 ## Log and Trace Correlations
-By default, the Datadog trace id gets automatically injected into the logs for correlation, if using the AWS provided `LambdaLoggerHandler`.
+By default, the Datadog trace id gets automatically injected into the logs for correlation, if using the standard python `logging` library.
 
 If you use a custom logger handler to log in json, you can manually inject the ids using the helper function `get_correlation_ids`.
 

--- a/datadog_lambda/__init__.py
+++ b/datadog_lambda/__init__.py
@@ -1,6 +1,6 @@
 # The minor version corresponds to the Lambda layer version.
 # E.g.,, version 0.5.0 gets packaged into layer version 5.
-__version__ = "1.12.0"
+__version__ = "2.13.0"
 
 
 import os

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -47,7 +47,9 @@ class _LambdaDecorator(object):
     def __init__(self, func):
         self.func = func
         self.flush_to_log = os.environ.get("DD_FLUSH_TO_LOG", "").lower() == "true"
-        self.logs_injection = os.environ.get("DD_LOGS_INJECTION", "").lower() == "true"
+        self.logs_injection = (
+            os.environ.get("DD_LOGS_INJECTION", "true").lower() == "true"
+        )
 
         # Inject trace correlation ids to logs
         if self.logs_injection:

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -89,7 +89,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         self.mock_wrapper_lambda_stats.flush.assert_called()
         self.mock_extract_dd_trace_context.assert_called_with(lambda_event)
         self.mock_set_correlation_ids.assert_called()
-        self.mock_inject_correlation_ids.assert_not_called()
+        self.mock_inject_correlation_ids.assert_called()
         self.mock_patch_all.assert_called()
 
     def test_datadog_lambda_wrapper_flush_to_log(self):


### PR DESCRIPTION
### What does this PR do?

Enables trace log context injection by default. Also bumps the major version number since this is a breaking change.
