### PR TITLE
Try never break the wrapped lambda function

### DIFF
--- a/tests/integration/handle.py
+++ b/tests/integration/handle.py
@@ -1,5 +1,3 @@
-import json
-
 from datadog_lambda.metric import lambda_metric
 from datadog_lambda.wrapper import datadog_lambda_wrapper
 

--- a/tests/integration/http_requests.py
+++ b/tests/integration/http_requests.py
@@ -1,4 +1,3 @@
-import json
 import requests
 
 from datadog_lambda.metric import lambda_metric
@@ -12,7 +11,7 @@ def handle(event, context):
         "tests.integration.count", 21, tags=["test:integration", "role:hello"]
     )
 
-    us_response = requests.get("https://ip-ranges.datadoghq.com/")
-    eu_response = requests.get("https://ip-ranges.datadoghq.eu/")
+    requests.get("https://ip-ranges.datadoghq.com/")
+    requests.get("https://ip-ranges.datadoghq.eu/")
 
     return {"statusCode": 200, "body": {"message": "hello, dog!"}}

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -26,7 +26,7 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
     def setUp(self):
         # Force @datadog_lambda_wrapper to always create a real
         # (not no-op) wrapper.
-        datadog_lambda_wrapper._force_new = True
+        datadog_lambda_wrapper._force_wrap = True
 
         patcher = patch("datadog_lambda.metric.lambda_stats")
         self.mock_metric_lambda_stats = patcher.start()
@@ -265,9 +265,9 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
         def lambda_handler(event, context):
             lambda_metric("test.metric", 100)
 
-        # Turn off _force_new to emulate the nested wrapper scenario,
+        # Turn off _force_wrap to emulate the nested wrapper scenario,
         # the second @datadog_lambda_wrapper should actually be no-op.
-        datadog_lambda_wrapper._force_new = False
+        datadog_lambda_wrapper._force_wrap = False
 
         lambda_handler_double_wrapped = datadog_lambda_wrapper(lambda_handler)
 


### PR DESCRIPTION
### What does this PR do?

- patch `requests` only when it's installed and used
- do not throw when `requests` is called explicitly with `headers=None` (should be a dict)
- swallow exceptions from datadog wrapper logic

### Checklist

- [x] Member of the Datadog team has run integration tests and updated snapshots if necessary
