### PR TITLE
Publish and list layers in ap-east-1 as well

### DIFF
--- a/scripts/list_layers.sh
+++ b/scripts/list_layers.sh
@@ -9,7 +9,7 @@
 # Optionals args: [layer-name] [region]
 
 LAYER_NAMES=("Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
-AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1)
+AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-east-1 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1)
 
 # Check region arg
 if [ -z "$2" ]; then

--- a/scripts/publish_layers.sh
+++ b/scripts/publish_layers.sh
@@ -16,7 +16,7 @@ trap "pkill -P $$; exit 1;" INT
 PYTHON_VERSIONS_FOR_AWS_CLI=("python2.7" "python3.6" "python3.7" "python3.8")
 LAYER_PATHS=(".layers/datadog_lambda_py2.7.zip" ".layers/datadog_lambda_py3.6.zip" ".layers/datadog_lambda_py3.7.zip" ".layers/datadog_lambda_py3.8.zip")
 AVAILABLE_LAYER_NAMES=("Datadog-Python27" "Datadog-Python36" "Datadog-Python37" "Datadog-Python38")
-AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1)
+AVAILABLE_REGIONS=(us-east-2 us-east-1 us-west-1 us-west-2 ap-east-1 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 ca-central-1 eu-north-1 eu-central-1 eu-west-1 eu-west-2 eu-west-3 sa-east-1)
 
 # Check that the layer files exist
 for layer_file in "${LAYER_PATHS[@]}"


### PR DESCRIPTION
_Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-python/blob/master/CONTRIBUTING.md)
if you have not yet done so._

### What does this PR do?

This enables publishing and listing layers in ap-east-1 alongside all other regions

### Motivation

We can not use the datadog-log-forwarder in ap-east-1.
https://github.com/DataDog/datadog-serverless-functions/tree/master/aws/logs_monitoring

### Testing Guidelines

No testing has been performed.

### Additional Notes

Yes, Hong Kong is using another type of token when talking to the AWS API, version 2. Thus I recommend that this is tested in your AWS environment before accepting.

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html

### Checklist

- [ ] Member of the Datadog team has run integration tests and updated snapshots if necessary
