### PR TITLE
Lowercase function arn in trace metadata

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -238,9 +238,10 @@ def create_function_execution_span(
 ):
     tags = {}
     if context:
+        function_arn = (context.invoked_function_arn or "").lower()
         tags = {
             "cold_start": str(is_cold_start).lower(),
-            "function_arn": context.invoked_function_arn,
+            "function_arn": function_arn,
             "request_id": context.aws_request_id,
             "resource_names": context.function_name,
         }


### PR DESCRIPTION
### What does this PR do?

Lowercases the function arn on dd-trace metadata. This ensures the function_arn is viewable on the datadog serverless page trace list.

- [ ] Member of the Datadog team has run integration tests and updated snapshots if necessary
