### PR TITLE
Upgrade AWS X-Ray SDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=["datadog_lambda"],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4",
     install_requires=[
-        "aws-xray-sdk==2.4.3",
+        "aws-xray-sdk==2.5.0",
         "datadog==0.32.0",
         "ddtrace==0.36.0",
         "wrapt==1.11.2",


### PR DESCRIPTION
_Note: Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-python/blob/master/CONTRIBUTING.md)
if you have not yet done so._

### What does this PR do?

This PR upgrades the version of AWS X-Ray SDK to v2.5.0

### Motivation

I have recently submitted patch support for `PyMySQL` (client library for MySQL) in X-Ray SDK [#214](https://github.com/aws/aws-xray-sdk-python/issues/214) which is merged and released in XRay SDK v2.5.0.

After upgrading our serverless application with the latest version of SDK,  got errors from Xray SDK that `pymysql` was not a supported module. I raised a request in the SDK repo [#219](https://github.com/aws/aws-xray-sdk-python/issues/219). Upon further investigation, I found out that Datadog's layer is overriding the SDK version in our deployment package. We also use lambda layers to package our dependencies. Upgrading AWS Xray SDK to v2.5.0 in Datadog's layer will solve this issue for us.

### Testing Guidelines

How did you test this pull request?

I ran `./scripts/run_tests.sh`

### Additional Notes

It's important that this gets merged soon as our application is dependent on it and we need MySQL instrumentation support as quickly as possible. 

### Checklist

- [x] Member of the Datadog team has run integration tests and updated snapshots if necessary
