### PR TITLE
Fix parent source as being set as Xray, when trace merging disabled

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -234,7 +234,7 @@ def set_dd_trace_py_root(trace_context, merge_xray_traces):
 
 
 def create_function_execution_span(
-    context, function_name, is_cold_start, trace_context
+    context, function_name, is_cold_start, trace_context, merge_xray_traces
 ):
     tags = {}
     if context:
@@ -246,7 +246,7 @@ def create_function_execution_span(
             "resource_names": context.function_name,
         }
     source = trace_context["source"]
-    if source != TraceContextSource.DDTRACE:
+    if source == TraceContextSource.XRAY and merge_xray_traces:
         tags["_dd.parent_source"] = source
 
     args = {

--- a/datadog_lambda/wrapper.py
+++ b/datadog_lambda/wrapper.py
@@ -122,7 +122,11 @@ class _LambdaDecorator(object):
             if dd_tracing_enabled:
                 set_dd_trace_py_root(dd_context, self.merge_xray_traces)
                 self.span = create_function_execution_span(
-                    context, self.function_name, is_cold_start(), dd_context
+                    context,
+                    self.function_name,
+                    is_cold_start(),
+                    dd_context,
+                    self.merge_xray_traces,
                 )
             else:
                 set_correlation_ids()


### PR DESCRIPTION
### What does this PR do?

Currently, the layer will set a metadata field on the root dd-trace span called '_dd.parent_source'  to 'xray' even when x-ray merging is disabled. That field is used by the trace forwarder to filter out spans, to reduce duplication between x-ray and dd-trace traces.  This PR fixes that issue, so that when x-ray trace merging is disabled, the field remains unset, and the root span is never filtered out.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

How did you test this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Checklist

- [ ] Member of the Datadog team has run integration tests and updated snapshots if necessary
