### PR TITLE
Add default lambda handler, for zero-code change instrumentation

### DIFF
--- a/datadog_lambda/handler.py
+++ b/datadog_lambda/handler.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+from importlib import import_module
+import os
+from datadog_lambda.wrapper import datadog_lambda_wrapper
+
+
+class HandlerError(Exception):
+    pass
+
+
+path = os.environ.get("DATADOG_USER_HANDLER", None)
+if path is None:
+    raise HandlerError(
+        "DATADOG_USER_HANDLER is not defined. Can't use prebuilt datadog handler"
+    )
+parts = path.rsplit(".", 1)
+if len(parts) != 2:
+    raise HandlerError("Value %s for DATADOG_USER_HANDLER has invalid format." % path)
+
+(mod_name, handler_name) = parts
+handler_module = import_module(mod_name)
+handler = datadog_lambda_wrapper(getattr(handler_module, handler_name))

--- a/datadog_lambda/handler.py
+++ b/datadog_lambda/handler.py
@@ -1,5 +1,11 @@
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2020 Datadog, Inc.
+
 from __future__ import absolute_import
 from importlib import import_module
+
 import os
 from datadog_lambda.wrapper import datadog_lambda_wrapper
 

--- a/datadog_lambda/handler.py
+++ b/datadog_lambda/handler.py
@@ -14,14 +14,14 @@ class HandlerError(Exception):
     pass
 
 
-path = os.environ.get("DATADOG_USER_HANDLER", None)
+path = os.environ.get("DD_LAMBDA_HANDLER", None)
 if path is None:
     raise HandlerError(
-        "DATADOG_USER_HANDLER is not defined. Can't use prebuilt datadog handler"
+        "DD_LAMBDA_HANDLER is not defined. Can't use prebuilt datadog handler"
     )
 parts = path.rsplit(".", 1)
 if len(parts) != 2:
-    raise HandlerError("Value %s for DATADOG_USER_HANDLER has invalid format." % path)
+    raise HandlerError("Value %s for DD_LAMBDA_HANDLER has invalid format." % path)
 
 (mod_name, handler_name) = parts
 handler_module = import_module(mod_name)


### PR DESCRIPTION
### What does this PR do?

Adds a 'handler' file, that can be pointed to by the user without having to change their code. Using this file involves two steps.

Set the handler to ''datadog_lambda.handler.handler"
Set 'DD_LAMBDA_HANDLER' to the actual handler

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

How did you test this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Checklist

- [ ] Member of the Datadog team has run integration tests and updated snapshots if necessary
