### PR TITLE
Add out_of_memory metric

### DIFF
--- a/datadog_lambda/metric.py
+++ b/datadog_lambda/metric.py
@@ -112,6 +112,15 @@ def submit_errors_metric(lambda_context):
     submit_enhanced_metric("errors", lambda_context)
 
 
+def submit_out_of_memory_metric(lambda_context):
+    """Increment aws.lambda.enhanced.out_of_memory by 1, applying runtime, layer, and cold_start tags
+
+    Args:
+        lambda_context (dict): Lambda context dict passed to the function by AWS
+    """
+    submit_enhanced_metric("out_of_memory", lambda_context)
+
+
 # Set API Key and Host in the module, so they only set once per container
 if not api._api_key:
     DD_API_KEY_SECRET_ARN = os.environ.get("DD_API_KEY_SECRET_ARN", "")

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -199,6 +199,63 @@ class TestDatadogLambdaWrapper(unittest.TestCase):
             ]
         )
 
+    def test_out_of_memory_metric(self):
+        @datadog_lambda_wrapper
+        def lambda_handler(event, context):
+            raise MemoryError()
+
+        lambda_event = {}
+
+        with self.assertRaises(MemoryError):
+            lambda_handler(lambda_event, get_mock_context())
+
+        self.mock_write_metric_point_to_stdout.assert_has_calls(
+            [
+                call(
+                    "aws.lambda.enhanced.invocations",
+                    1,
+                    tags=[
+                        "region:us-west-1",
+                        "account_id:123457598159",
+                        "functionname:python-layer-test",
+                        "resource:python-layer-test:1",
+                        "cold_start:true",
+                        "memorysize:256",
+                        "runtime:python2.7",
+                        "dd_lambda_layer:datadog-python27_0.1.0",
+                    ],
+                ),
+                call(
+                    "aws.lambda.enhanced.out_of_memory",
+                    1,
+                    tags=[
+                        "region:us-west-1",
+                        "account_id:123457598159",
+                        "functionname:python-layer-test",
+                        "resource:python-layer-test:1",
+                        "cold_start:true",
+                        "memorysize:256",
+                        "runtime:python2.7",
+                        "dd_lambda_layer:datadog-python27_0.1.0",
+                    ],
+                ),
+                call(
+                    "aws.lambda.enhanced.errors",
+                    1,
+                    tags=[
+                        "region:us-west-1",
+                        "account_id:123457598159",
+                        "functionname:python-layer-test",
+                        "resource:python-layer-test:1",
+                        "cold_start:true",
+                        "memorysize:256",
+                        "runtime:python2.7",
+                        "dd_lambda_layer:datadog-python27_0.1.0",
+                    ],
+                ),
+            ]
+        )
+
     def test_enhanced_metrics_cold_start_tag(self):
         @datadog_lambda_wrapper
         def lambda_handler(event, context):


### PR DESCRIPTION
### What does this PR do?

Adds `aws.lambda.enhanced.out_of_memory` metric.

### Testing Guidelines

<!--- How did you test this pull request? --->

### Types of Changes

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [ ] This PR passes the integration tests (ask a Datadog member to run the tests)
