### PR TITLE
Parse function version from function arn

### DIFF
--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -247,7 +247,7 @@ def create_function_execution_span(
         }
         tokens = function_arn.split(":")
         if len(tokens) > 7:
-            tags['function_arn'] = ":".join(tokens[0:6])
+            tags['function_arn'] = ":".join(tokens[0:7])
             tags['function_version'] = tokens[7]
     source = trace_context["source"]
     if source == TraceContextSource.XRAY and merge_xray_traces:

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -241,7 +241,7 @@ def create_function_execution_span(
         function_arn = (context.invoked_function_arn or "").lower()
         tk = function_arn.split(":")
         function_arn = ":".join(tk[0:7]) if len(tk) > 7 else function_arn
-        function_version = tk[7] if len(tk) > 7 else "$Latest"
+        function_version = tk[7] if len(tk) > 7 else "$LATEST"
         tags = {
             "cold_start": str(is_cold_start).lower(),
             "function_arn": function_arn,

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -239,16 +239,16 @@ def create_function_execution_span(
     tags = {}
     if context:
         function_arn = (context.invoked_function_arn or "").lower()
+        tk = function_arn.split(":")
+        function_arn = ":".join(tk[0:7]) if len(tk) > 7 else function_arn
+        function_version = tk[7] if len(tk) > 7 else "$Latest"
         tags = {
             "cold_start": str(is_cold_start).lower(),
             "function_arn": function_arn,
+            "function_version": function_version,
             "request_id": context.aws_request_id,
             "resource_names": context.function_name,
         }
-        tokens = function_arn.split(":")
-        if len(tokens) > 7:
-            tags["function_arn"] = ":".join(tokens[0:7])
-            tags["function_version"] = tokens[7]
     source = trace_context["source"]
     if source == TraceContextSource.XRAY and merge_xray_traces:
         tags["_dd.parent_source"] = source

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -247,8 +247,8 @@ def create_function_execution_span(
         }
         tokens = function_arn.split(":")
         if len(tokens) > 7:
-            tags['function_arn'] = ":".join(tokens[0:7])
-            tags['function_version'] = tokens[7]
+            tags["function_arn"] = ":".join(tokens[0:7])
+            tags["function_version"] = tokens[7]
     source = trace_context["source"]
     if source == TraceContextSource.XRAY and merge_xray_traces:
         tags["_dd.parent_source"] = source

--- a/datadog_lambda/tracing.py
+++ b/datadog_lambda/tracing.py
@@ -245,6 +245,10 @@ def create_function_execution_span(
             "request_id": context.aws_request_id,
             "resource_names": context.function_name,
         }
+        tokens = function_arn.split(":")
+        if len(tokens) > 7:
+            tags['function_arn'] = ":".join(tokens[0:6])
+            tags['function_version'] = tokens[7]
     source = trace_context["source"]
     if source == TraceContextSource.XRAY and merge_xray_traces:
         tags["_dd.parent_source"] = source

--- a/scripts/check_format.sh
+++ b/scripts/check_format.sh
@@ -8,8 +8,8 @@ if [ "$PYTHON_VERSION" = "2" ]; then
 fi
 pip install -Iv black==19.10b0
 
-python -m black --check datadog_lambda/
-python -m black --check tests
+python -m black --check datadog_lambda/ --diff
+python -m black --check tests --diff
 
 
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -219,7 +219,7 @@ class TestFunctionSpanTags(unittest.TestCase):
         ctx = get_mock_context()
         span = create_function_execution_span(ctx, "", False, {"source": ""}, False)
         self.assertEqual(span.get_tag("function_arn"), function_arn)
-        self.assertEqual(span.get_tag("function_version"), "$Latest")
+        self.assertEqual(span.get_tag("function_version"), "$LATEST")
 
     def test_function_with_version(self):
         function_version = "1"

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -219,6 +219,7 @@ class TestFunctionSpanTags(unittest.TestCase):
         ctx = get_mock_context()
         span = create_function_execution_span(ctx, "", False, {"source": ""}, False)
         self.assertEqual(span.get_tag("function_arn"), function_arn)
+        self.assertEqual(span.get_tag("function_version"), "$Latest")
 
     def test_function_with_version(self):
         function_version = "1"
@@ -234,4 +235,4 @@ class TestFunctionSpanTags(unittest.TestCase):
         ctx = get_mock_context(invoked_function_arn=function_arn + ":" + function_alias)
         span = create_function_execution_span(ctx, "", False, {"source": ""}, False)
         self.assertEqual(span.get_tag("function_arn"), function_arn)
-        self.assertEqual(span.get_tag("function_version"), "alias")
+        self.assertEqual(span.get_tag("function_version"), function_alias)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -223,19 +223,15 @@ class TestFunctionSpanTags(unittest.TestCase):
     def test_function_with_version(self):
         function_version = "1"
         ctx = get_mock_context(
-            invoked_function_arn=function_arn + ":" + function_version,
+            invoked_function_arn=function_arn + ":" + function_version
         )
         span = create_function_execution_span(ctx, "", False, {"source": ""}, False)
-        self.assertEqual(span.get_tag(
-            "function_arn"), function_arn)
+        self.assertEqual(span.get_tag("function_arn"), function_arn)
         self.assertEqual(span.get_tag("function_version"), function_version)
 
     def test_function_with_alias(self):
         function_alias = "alias"
-        ctx = get_mock_context(
-            invoked_function_arn=function_arn + ":" + function_alias
-        )
+        ctx = get_mock_context(invoked_function_arn=function_arn + ":" + function_alias)
         span = create_function_execution_span(ctx, "", False, {"source": ""}, False)
-        self.assertEqual(span.get_tag(
-            "function_arn"), function_arn)
+        self.assertEqual(span.get_tag("function_arn"), function_arn)
         self.assertEqual(span.get_tag("function_version"), "alias")


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-lambda-layer-rb/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This changes in the PR allow for parsing of the function version from the function arn if there is one. If there is no function version, then a default value of $LATEST is set.

### Motivation

https://datadoghq.atlassian.net/browse/SLS-588

### Testing Guidelines

Manually tested using a locally built version of datadog-lambda with the required changes, and making sure the changes make it all the way to the datadog traces.

### Types of Changes

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Misc (docs, refactoring, dependency upgrade, etc.)

### Check all that apply

- [x] This PR's description is comprehensive
- [ ] This PR contains breaking changes that are documented in the description
- [ ] This PR introduces new APIs or parameters that are documented and unlikely to change in the foreseeable future
- [ ] This PR impacts documentation, and it has been updated (or a ticket has been logged)
- [x] This PR's changes are covered by the automated tests
- [ ] This PR collects user input/sensitive content into Datadog
- [x] This PR passes the integration tests (ask a Datadog member to run the tests)
